### PR TITLE
Fix runtime env module export

### DIFF
--- a/scripts/runtime-env-fix.js
+++ b/scripts/runtime-env-fix.js
@@ -135,5 +135,6 @@ if (require.main === module) {
 module.exports = {
   fixEnvironmentFiles,
   checkEnvironmentStatus,
-  generateEnvScript
+  generateEnvScript,
+  main
 };


### PR DESCRIPTION
## Summary
- export `main` from `scripts/runtime-env-fix.js`

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a1e741fc832690051918cda63ee3